### PR TITLE
Enhance compatibility jpype

### DIFF
--- a/konlpy/jvm.py
+++ b/konlpy/jvm.py
@@ -50,7 +50,7 @@ def init_jvm(jvmpath=None, max_heap_size=1024):
     javadir = '%s%sjava' % (utils.installpath, os.sep)
 
     args = [javadir, os.sep]
-    classpath = os.pathsep.join(f.format(*args) for f in folder_suffix)
+    classpath = [f.format(*args) for f in folder_suffix]
 
     jvmpath = jvmpath or jpype.getDefaultJVMPath()
 
@@ -61,9 +61,9 @@ def init_jvm(jvmpath=None, max_heap_size=1024):
         jvmpath = '%s/lib/jli/libjli.dylib' % jvmpath.split('/lib/')[0]
 
     if jvmpath:
-        jpype.startJVM(jvmpath, '-Djava.class.path=%s' % classpath,
-                                '-Dfile.encoding=UTF8',
+        jpype.startJVM(jvmpath, '-Dfile.encoding=UTF8',
                                 '-ea', '-Xmx{}m'.format(max_heap_size),
+                                classpath=classpath,
                                 convertStrings=True)
     else:
         raise ValueError("Please specify the JVM path.")


### PR DESCRIPTION
Enhance compatibility jpype
-----

### 내용
- windows에서 konlpy 사용시  `java.nio.file.InvalidPathException` 오류를 해결하기 위한 방법입니다.
- startJVM을 호출할 때, `classpath를 karg로 지정`하여 문제를 해결합니다.
- 해당 pr을 통해 windows에서 사용성이 개선될 것으로 기대됩니다.

### java.nio.file.InvalidPathException 오류 원인
- 해당 오류는 startJVM을 호출시 나타나는 오류로, classpath에 *(asterisk)가 포함되어 발생하는 오류입니다.
  ```
  ...
  SystemError: java.nio.file.InvalidPathException: Illegal char <*> at index 84: C:\Users\test\AppData\Local\Programs\Python\Python38\Lib\site-packages\konlpy\java\*
  ```
- windows에서 Jpype1 버전에 따라 오류가 발생합니다.
- Jpype1-1.2.0 까지는 오류가 발생하지 않지만, 1.2.1부터는 해당 오류가 발생합니다.
  - Jpype1 내부적으로 어떤 변화가 있었는지 확인해봤지만, 명확한 원인은 알 수 없었습니다.

### Jpype startJVM

- [Jpype startJVM](https://jpype.readthedocs.io/en/latest/api.html#jpype.startJVM)을 보면 classpath를 별도로 지정할 수 있습니다.
```
classpath (str,[str]) – Set the classpath for the JVM. This will override any classpath supplied in the arguments list. A value of None will give no classpath to JVM.
```
- 특히 keyword argument를 통해 classpath를 직접 지정할 경우 jpype 내부에서 *에 대한 exception 처리를 합니다. 
  - https://github.com/jpype-project/jpype/blob/master/jpype/_core.py#L114

### 참고
- [CONTRIBUTING.rst#3-이슈-제안해결하기](https://github.com/konlpy/konlpy/blob/master/CONTRIBUTING.rst#3-%EC%9D%B4%EC%8A%88-%EC%A0%9C%EC%95%88%ED%95%B4%EA%B2%B0%ED%95%98%EA%B8%B0) 에 따라 make 

### 관련 이슈
- https://github.com/konlpy/konlpy/issues/363
- https://github.com/konlpy/konlpy/issues/349